### PR TITLE
Fix remaining R CMD check failures: scope RUN_SLOW_TESTS to all/nobioc

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -25,10 +25,13 @@ jobs:
           - {os: macos-latest,   r: 'release',  test: 'fast'}
           - {os: windows-latest, r: 'release',  test: 'fast'}
           - {os: windows-latest, r: 'oldrel-4', test: 'fast'}
+    # NB: RUN_SLOW_TESTS is intentionally NOT set at the job level. The
+    # per-step configuration below enables it only for the `all` and `nobioc`
+    # runs, so the `fast` jobs (macOS/Windows/older R) skip the slow, network-
+    # dependent tests (75 MB example-datasets download, etc.).
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
-      RUN_SLOW_TESTS: "TRUE"
     steps:
 
       - name: Checkout repository

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,10 @@
     * Download-dependent tests skip gracefully (new internal
       `skip_if_no_example_datasets()` helper) when the ~75 MB
       `example_datasets.zip` release asset cannot be downloaded.
+    * CI: `RUN_SLOW_TESTS` is no longer set at the job level in
+      `R-CMD-check.yaml`; it is enabled only for the `all`/`nobioc` steps. The
+      `fast` jobs (macOS/Windows/older R) now genuinely skip the slow,
+      network-dependent tests instead of running and flaking on them.
 
 # metabodecon 1.7.0
 


### PR DESCRIPTION
## Background

The v1.7.1 change (already on `main`) made the optional Rust backend `mdrb`
truly optional and fixed the `oldrel-4` R CMD check failures. However, the
`macos-latest (release, fast)` and `windows-latest (release, fast)` jobs still
failed — see run
[29273732087](https://github.com/spang-lab/metabodecon/actions/runs/29273732087).

## Root cause

The only remaining failure was `test-datadir.R:40` ("datadir works if
datadir_persistent=filled"). That test is gated by
`skip_if_slow_tests_disabled()`, but `RUN_SLOW_TESTS` was set at the **job
level**, so it leaked into the `fast` steps and forced the slow, network-
dependent test to run there.

On a fresh runner the test cannot pass: the `filled` mock only overrides
`datadir_persistent()`, while `datadir()`'s auto-selection depends on the
**real** `zip_persistent()` having a correctly-sized zip. `cache_example_datasets(persistent = NULL)`
only writes the persistent zip if it already exists, so on CI it downloads to
the temp location and `datadir()` returns the temp dir → `x != y`.

## Fix

Mirror `metabodeconplus`: set `RUN_SLOW_TESTS` only on the `all`/`nobioc`
steps, not at the job level. The `fast` jobs (macOS/Windows/older R) then
genuinely skip the slow, network-dependent tests; `all`/`nobioc` still run
them. (On the `all` job the `filled` test is `skip_on_os("linux")` anyway.)

Once this is green it will be squash-merged into `main`.