### PR TITLE
CI: run slow tests on one runner per OS (macOS/Windows + Ubuntu)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,13 +22,17 @@ jobs:
           - {os: ubuntu-latest,  r: 'oldrel-2', test: 'fast'}
           - {os: ubuntu-latest,  r: 'oldrel-3', test: 'fast'}
           - {os: ubuntu-latest,  r: 'oldrel-4', test: 'fast'}
-          - {os: macos-latest,   r: 'release',  test: 'fast'}
-          - {os: windows-latest, r: 'release',  test: 'fast'}
+          - {os: macos-latest,   r: 'release',  test: 'all'}
+          - {os: windows-latest, r: 'release',  test: 'all'}
           - {os: windows-latest, r: 'oldrel-4', test: 'fast'}
-    # NB: RUN_SLOW_TESTS is intentionally NOT set at the job level. The
-    # per-step configuration below enables it only for the `all` and `nobioc`
-    # runs, so the `fast` jobs (macOS/Windows/older R) skip the slow, network-
-    # dependent tests (75 MB example-datasets download, etc.).
+    # NB: RUN_SLOW_TESTS is intentionally NOT set at the job level; the
+    # per-step config below enables it only for the `all`/`nobioc` runs. The
+    # slow, network-dependent tests (75 MB example-datasets download, etc.) are
+    # thus exercised on at least one runner per OS -- ubuntu (all + nobioc),
+    # macOS (release, all) and windows (release, all) -- while the remaining
+    # `fast` jobs (ubuntu devel/oldrel, windows oldrel-4) skip them. Download
+    # failures skip gracefully via skip_if_no_example_datasets(), so the slow
+    # jobs do not flake on transient network errors.
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,9 +14,14 @@
       `skip_if_no_example_datasets()` helper) when the ~75 MB
       `example_datasets.zip` release asset cannot be downloaded.
     * CI: `RUN_SLOW_TESTS` is no longer set at the job level in
-      `R-CMD-check.yaml`; it is enabled only for the `all`/`nobioc` steps. The
-      `fast` jobs (macOS/Windows/older R) now genuinely skip the slow,
-      network-dependent tests instead of running and flaking on them.
+      `R-CMD-check.yaml`; it is enabled per-step for the `all`/`nobioc` runs.
+      The slow, network-dependent tests are exercised on at least one runner
+      per OS -- ubuntu (`all` + `nobioc`), macOS (`release`, `all`) and windows
+      (`release`, `all`) -- so the OS-specific slow tests (e.g. the persistent
+      `datadir()` test, which is `skip_on_os("linux")`) keep their coverage,
+      while the remaining `fast` jobs (older R, windows `oldrel-4`) skip them.
+      Download failures skip gracefully, so the slow jobs no longer flake on
+      transient network errors.
 
 # metabodecon 1.7.0
 

--- a/R/test.R
+++ b/R/test.R
@@ -286,7 +286,21 @@ get_datadir_mock <- function(type = "temp", state = "default") {
     p <- norm_path(file.path(mockdir(), "datadir", type, state))
     if (state %in% c("missing", "empty")) unlink(p, recursive = TRUE, force = TRUE)
     if (state == "empty") mkdirs(p)
-    if (state == "filled") download_example_datasets(dst_dir = p, silent = TRUE)
+    if (state == "filled") {
+        download_example_datasets(dst_dir = p, silent = TRUE)
+        # datadir() auto-selects the persistent dir via
+        # `file.size(zip_persistent()) == xds$zip_size`. The copy step inside
+        # download_example_datasets() is conditional and left the zip
+        # absent/short on macOS/Windows CI, so datadir() fell back to temp and
+        # this mock's `datadir()` == `datadir(persistent=TRUE)` assertion
+        # failed. Copy the already-validated cached zip to the mocked
+        # persistent zip path so the auto-selection is deterministic on all OSes.
+        zp <- file.path(p, "example_datasets.zip")
+        if (!isTRUE(file.size(zp) == xds$zip_size)) {
+            src <- cache_example_datasets(persistent = FALSE, extract = FALSE, silent = TRUE)
+            file.copy(src, zp, overwrite = TRUE)
+        }
+    }
     function() p
 }
 


### PR DESCRIPTION
## What

Promote the **macOS-release** and **Windows-release** `R-CMD-check` jobs from the `fast` variant to `all`, so `RUN_SLOW_TESTS=TRUE` runs on **at least one runner per OS**:

- ubuntu-latest (`all` + `nobioc`)
- macos-latest (`release`, `all`)
- windows-latest (`release`, `all`)

## Why

Commit 3cbe717 moved `RUN_SLOW_TESTS` off the job level so the `fast` jobs stop flaking on the 75 MB download. But it left the slow **testthat** suite running on **Ubuntu only** — macOS/Windows got zero slow-test coverage, and the OS-specific `test-datadir.R` persistent test (gated by both `skip_if_slow_tests_disabled()` and `skip_on_os("linux")`) ended up running on **no** CI job at all.

This restores per-OS coverage. Download failures skip gracefully via `skip_if_no_example_datasets()`, so the slow jobs don't flake on transient network errors.

## Verification

This PR exists to exercise the new matrix on macOS + Windows with slow tests enabled.