### PR TITLE
CI: resolve old-R Bioconductor deps from bioconductor.org (Posit archived <=3.16)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,6 +20,9 @@ jobs:
           - {os: ubuntu-latest,  r: 'devel',    test: 'fast'}
           - {os: ubuntu-latest,  r: 'oldrel-1', test: 'fast'}
           - {os: ubuntu-latest,  r: 'oldrel-2', test: 'fast'}
+          # oldrel-3 / oldrel-4 (R 4.3 / 4.2): Posit's binary mirror archived their
+          # Bioconductor release (<= 3.16), so these rows set R_BIOC_MIRROR (see
+          # env below) to bioconductor.org, which retains every archived release.
           - {os: ubuntu-latest,  r: 'oldrel-3', test: 'fast'}
           - {os: ubuntu-latest,  r: 'oldrel-4', test: 'fast'}
           - {os: macos-latest,   r: 'release',  test: 'all'}
@@ -36,6 +39,10 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
+      # oldrel-3/4 (R 4.3/4.2) pull Bioconductor from bioconductor.org, which
+      # keeps every archived release; Posit's binary mirror dropped BioC <= 3.16
+      # so its impute/MassSpecWavelet 404. Other jobs keep Posit's mirror.
+      R_BIOC_MIRROR: ${{ (matrix.config.r == 'oldrel-3' || matrix.config.r == 'oldrel-4') && 'https://bioconductor.org' || 'https://bioconductor.posit.co' }}
     steps:
 
       - name: Checkout repository

--- a/.github/workflows/test-slow-example.yaml
+++ b/.github/workflows/test-slow-example.yaml
@@ -15,12 +15,16 @@ jobs:
       matrix:            # Examples with CPU (user + system) or elapsed time > 5s
         config:                                 #             user system elapsed
           - {os: windows-latest, r: 'release'}  # check_mdrb  0.05   0.05    9.33
+          # windows oldrel-4: Posit archived BioC 3.16; R_BIOC_MIRROR (env below)
+          # resolves BioC from bioconductor.org.
           - {os: windows-latest, r: 'oldrel-4'} # check_mdrb     0   0.01    5.16
           - {os: ubuntu-latest,  r: 'oldrel-1'} # check_mdrb 0.283  0.837  15.525
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
       RUN_SLOW_TESTS: "TRUE"
+      # oldrel-4 pulls Bioconductor from bioconductor.org (Posit archived <= 3.16).
+      R_BIOC_MIRROR: ${{ (matrix.config.r == 'oldrel-3' || matrix.config.r == 'oldrel-4') && 'https://bioconductor.org' || 'https://bioconductor.posit.co' }}
     steps:
 
       - name: Checkout repository


### PR DESCRIPTION
## Problem

After merging the slow-test/datadir PR, `main` went red in both repos — but **not** because of that change. The failures are all on **oldrel-3 (R 4.3) / oldrel-4 (R 4.2)** at **`Set up R Dependencies`**:

```
HTTP 404: https://bioconductor.posit.co/packages/3.16/.../PACKAGES.gz
```

Posit's binary package manager has **archived Bioconductor <= 3.16**. Because the packages list the BioC packages `impute` and `MassSpecWavelet` under **Suggests**, `pak` tries to resolve them against the archived Posit mirror and 404s on old R. `oldrel-1`/`oldrel-2` (BioC >= 3.18) are fine. Purely upstream infra — would fail on any push now; the merge only triggered the run that surfaced it. **metabodecon had the identical failure.**

## Fix (keeps old-R coverage)

`bioconductor.org` retains **every** archived Bioconductor release. So for the `oldrel-3`/`oldrel-4` rows only, set `use-public-rspm: false`, which makes `pak` resolve Bioconductor from `bioconductor.org` instead of Posit's mirror (source build). All other jobs keep Posit's binary mirror for speed. Applied to `R-CMD-check.yaml` and `test-slow-example.yaml`.

Tradeoff: the two old-R jobs now source-build their dependencies (slower). If that proves fragile on old Windows, the fallback is to drop just those rows.