### PR TITLE
CI: skip the align dependency-install test on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,12 @@
       while the remaining `fast` jobs (older R, windows `oldrel-4`) skip them.
       Download failures skip gracefully, so the slow jobs no longer flake on
       transient network errors.
+    * The slow test `"align can install its dependencies"` is now
+      `skip_on_os("windows")`. It unloads and reinstalls the compiled
+      Bioconductor packages `impute`/`MassSpecWavelet` across a swapped
+      `.libPaths()`, which crashes the R session on Windows because the package
+      DLLs stay loaded and locked after `unloadNamespace()`. The logic under
+      test is OS-independent and remains covered on ubuntu and macOS.
 
 # metabodecon 1.7.0
 

--- a/tests/testthat/test-align.R
+++ b/tests/testthat/test-align.R
@@ -148,6 +148,16 @@ skip_if_slow_tests_disabled()
 
 test_that("align can install its dependencies", {
 
+    # NOT RUNNABLE ON WINDOWS: this test unloads the compiled Bioconductor
+    # packages `impute` and `MassSpecWavelet`, swaps `.libPaths()` and then
+    # reloads them from a fresh library. On Windows, `unloadNamespace()` does
+    # not unload the package DLL and the file stays locked, so re-registering
+    # the native routines from the newly installed copy crashes the R session
+    # with an access violation (exit code -1073741819 / 0xC0000005) rather than
+    # failing an expectation. The auto-installation logic under test is
+    # OS-independent and stays covered by the ubuntu and macOS runners.
+    skip_on_os("windows")
+
     # TEST PURPOSE: If `metabodecon` or `speaq` is installed via
     # `install.packages()`, the dependencies `impute` and `MassSpecWavelet`
     # may not be installed. In this case, the missing dependencies should be


### PR DESCRIPTION
## Problem

`windows-latest (release, all)` fails in [run 29722870856](https://github.com/spang-lab/metabodecon/actions/runs/29722870856/job/88289403453):

```
> test-align.R:
Error:
! testthat subprocess exited in file 'test-align.R'.
Caused by error:
! R session crashed with exit code -1073741819
```

`-1073741819` is `0xC0000005` — a Windows access violation, i.e. a hard segfault, not a failed expectation.

## Diagnosis

The culprit is the slow test `"align can install its dependencies"`. It unloads the compiled Bioconductor packages `impute` and `MassSpecWavelet`, swaps `.libPaths()` to a fresh empty library, copies `speaq` over and then lets `align(install_deps = TRUE)` reinstall the dependencies.

On Windows `unloadNamespace()` does not unload the package DLL and the file stays locked, so re-registering the native routines from the newly installed copy crashes the session.

Evidence that this — and not the optional Rust backend — is the trigger:

- `mdrb` installs successfully in **both** Windows jobs, yet `windows-latest (oldrel-4, fast)` passes `test-align.R`. So `mdrb` is not the differentiator.
- `RUN_SLOW_TESTS` is the only difference between the two Windows jobs, and the crashing test is the sole slow test in `test-align.R`.
- The failure is a regression from b3112d7, which flipped the `windows-latest` release job from `fast` to `all` and thereby enabled `RUN_SLOW_TESTS` on Windows for the first time.

## Fix

`skip_on_os("windows")` for that one test, with a comment explaining why. The auto-installation logic under test is OS-independent and stays covered by the ubuntu (`all` + `nobioc`) and macOS (`release, all`) runners, so no coverage is lost.

This PR exists mainly to confirm the matrix actually goes green — the crash cannot be reproduced locally.